### PR TITLE
Fix link in README so it actually points to your website

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the exploit for Windscribe's v2.9.9 macOS client.
 
 Blogpost is here:
-[http://127.0.0.1:8000/why-you-shouldnt-use-a-commercial-vpn-amateur-hour-with-windscribe.html](http://127.0.0.1:8000/why-you-shouldnt-use-a-commercial-vpn-amateur-hour-with-windscribe.html)
+[https://gergelykalman.com/why-you-shouldnt-use-a-commercial-vpn-amateur-hour-with-windscribe.html](https://gergelykalman.com/why-you-shouldnt-use-a-commercial-vpn-amateur-hour-with-windscribe.html)
 
 
 ### Demo:


### PR DESCRIPTION
The current link probably only works on your local machine, I updated it to point to your public blog website instead.